### PR TITLE
Add Post service and controller tests with H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,17 @@
 			<artifactId>spring-boot-starter-tomcat</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/test/java/com/fidelitytechnologies/training/blogapp/controllers/PostControllerTest.java
+++ b/src/test/java/com/fidelitytechnologies/training/blogapp/controllers/PostControllerTest.java
@@ -1,0 +1,142 @@
+package com.fidelitytechnologies.training.blogapp.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fidelitytechnologies.training.blogapp.model.Category;
+import com.fidelitytechnologies.training.blogapp.model.Tag;
+import com.fidelitytechnologies.training.blogapp.model.dto.CategoryDto;
+import com.fidelitytechnologies.training.blogapp.model.dto.PostDto;
+import com.fidelitytechnologies.training.blogapp.model.dto.TagDto;
+import com.fidelitytechnologies.training.blogapp.repositories.CategoryRepository;
+import com.fidelitytechnologies.training.blogapp.repositories.PostRepository;
+import com.fidelitytechnologies.training.blogapp.repositories.TagRepository;
+import com.fidelitytechnologies.training.blogapp.services.PostService;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @BeforeEach
+    void setup() {
+        postRepository.deleteAll();
+        tagRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+
+    private PostDto buildPostDto(String title, Long tagId, Long categoryId) {
+        TagDto tagDto = new TagDto();
+        tagDto.setId(tagId);
+        CategoryDto categoryDto = new CategoryDto();
+        categoryDto.setId(categoryId);
+        PostDto dto = new PostDto();
+        dto.setTitle(title);
+        dto.setMetaTitle("meta");
+        dto.setSummary("summary");
+        dto.setContent("content");
+        dto.setTags(Arrays.asList(tagDto));
+        dto.setCategories(Arrays.asList(categoryDto));
+        return dto;
+    }
+
+    @Test
+    void testCreatePostEndpoint() throws Exception {
+        Tag tag = tagRepository.save(new Tag("spring", "meta", "spring", "desc"));
+        Category category = new Category();
+        category.setName("tech");
+        category.setDescription("desc");
+        category = categoryRepository.save(category);
+        PostDto dto = buildPostDto("New Post", tag.getId(), category.getId());
+        mockMvc.perform(post("/v1/blog_manager_area/post/create")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("New Post"));
+    }
+
+    @Test
+    void testEditPostEndpoint() throws Exception {
+        Tag tag = tagRepository.save(new Tag("spring", "meta", "spring", "desc"));
+        Category category = new Category();
+        category.setName("tech");
+        category.setDescription("desc");
+        category = categoryRepository.save(category);
+        PostDto created = postService.createPost(null, buildPostDto("Old", tag.getId(), category.getId()));
+
+        PostDto changes = new PostDto();
+        changes.setTitle("Updated");
+        changes.setMetaTitle("meta2");
+        changes.setSummary("summary2");
+        changes.setContent("content2");
+
+        mockMvc.perform(put("/v1/blog_manager_area/post/edit/" + created.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(changes)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Updated"));
+    }
+
+    @Test
+    void testDeletePostEndpoint() throws Exception {
+        Tag tag = tagRepository.save(new Tag("spring", "meta", "spring", "desc"));
+        Category category = new Category();
+        category.setName("tech");
+        category.setDescription("desc");
+        category = categoryRepository.save(category);
+        PostDto created = postService.createPost(null, buildPostDto("ToDelete", tag.getId(), category.getId()));
+
+        mockMvc.perform(delete("/v1/blog_manager_area/post/delete/" + created.getId()))
+                .andExpect(status().isOk());
+        assertEquals(0, postRepository.count());
+    }
+
+    @Test
+    void testSearchByTagEndpoint() throws Exception {
+        Tag tag = tagRepository.save(new Tag("spring", "meta", "spring", "desc"));
+        Category category = new Category();
+        category.setName("tech");
+        category.setDescription("desc");
+        category = categoryRepository.save(category);
+        postService.createPost(null, buildPostDto("Searchable", tag.getId(), category.getId()));
+
+        mockMvc.perform(get("/v1/blog_manager_area/post/search_by_tag/spring"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Searchable"));
+    }
+}

--- a/src/test/java/com/fidelitytechnologies/training/blogapp/services/PostServiceTest.java
+++ b/src/test/java/com/fidelitytechnologies/training/blogapp/services/PostServiceTest.java
@@ -1,0 +1,104 @@
+package com.fidelitytechnologies.training.blogapp.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fidelitytechnologies.training.blogapp.model.Category;
+import com.fidelitytechnologies.training.blogapp.model.Tag;
+import com.fidelitytechnologies.training.blogapp.model.dto.CategoryDto;
+import com.fidelitytechnologies.training.blogapp.model.dto.PostDto;
+import com.fidelitytechnologies.training.blogapp.model.dto.TagDto;
+import com.fidelitytechnologies.training.blogapp.repositories.CategoryRepository;
+import com.fidelitytechnologies.training.blogapp.repositories.PostRepository;
+import com.fidelitytechnologies.training.blogapp.repositories.TagRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostServiceTest {
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @BeforeEach
+    void setUp() {
+        postRepository.deleteAll();
+        tagRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+
+    private PostDto buildPostDto(String title) {
+        Tag tag = tagRepository.save(new Tag("tech", "meta", "tech", "desc"));
+        Category category = new Category();
+        category.setName("general");
+        category.setDescription("desc");
+        category = categoryRepository.save(category);
+
+        TagDto tagDto = new TagDto();
+        tagDto.setId(tag.getId());
+        CategoryDto categoryDto = new CategoryDto();
+        categoryDto.setId(category.getId());
+
+        PostDto post = new PostDto();
+        post.setTitle(title);
+        post.setMetaTitle("meta");
+        post.setSummary("summary");
+        post.setContent("content");
+        post.setTags(Arrays.asList(tagDto));
+        post.setCategories(Arrays.asList(categoryDto));
+        return post;
+    }
+
+    @Test
+    void testCreatePost() {
+        PostDto post = buildPostDto("First Post");
+        PostDto saved = postService.createPost(null, post);
+        assertNotNull(saved.getId());
+        assertEquals(1, postRepository.count());
+    }
+
+    @Test
+    void testModifyPost() {
+        PostDto post = postService.createPost(null, buildPostDto("Original"));
+        PostDto changes = new PostDto();
+        changes.setTitle("Updated");
+        changes.setMetaTitle("meta2");
+        changes.setSummary("summary2");
+        changes.setContent("content2");
+        PostDto updated = postService.modifyPost(null, post.getId(), changes);
+        assertEquals("Updated", updated.getTitle());
+    }
+
+    @Test
+    void testDeletePost() {
+        PostDto post = postService.createPost(null, buildPostDto("To Delete"));
+        assertEquals(1, postRepository.count());
+        postService.deletePostByID(null, post.getId());
+        assertEquals(0, postRepository.count());
+    }
+
+    @Test
+    void testSearchPostByTitle() {
+        postService.createPost(null, buildPostDto("Alpha"));
+        postService.createPost(null, buildPostDto("Beta"));
+        List<PostDto> found = postService.getPostByTitle("Alpha");
+        assertEquals(1, found.size());
+        assertEquals("Alpha", found.get(0).getTitle());
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false


### PR DESCRIPTION
## Summary
- configure in-memory H2 database for tests
- add unit tests for PostService covering create, update, delete and search
- add MockMvc controller tests for PostController endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.fidelitytechnologies.training:FidelityBlogApp:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_689a2cad04ac8328b8d15ab12aa65fd5